### PR TITLE
Correct ids relation in the degree programs overview shortcode

### DIFF
--- a/src/Infrastructure/Repository/WpQueryArgs.php
+++ b/src/Infrastructure/Repository/WpQueryArgs.php
@@ -39,12 +39,12 @@ final class WpQueryArgs
         return $this->withArg('orderby', $orderBy);
     }
 
-    public function withTaxQueryItem(array $item, string $relation = 'AND'): self
+    public function withTaxQueryItem(array $item): self
     {
         $instance = clone $this;
 
         $instance->args['tax_query'] = (array) ($instance->args['tax_query']
-            ?? ['relation' => $relation]);
+            ?? ['relation' => 'AND']);
 
         $instance->args['tax_query'][] = $item;
 

--- a/src/Infrastructure/Repository/WpQueryArgs.php
+++ b/src/Infrastructure/Repository/WpQueryArgs.php
@@ -39,12 +39,12 @@ final class WpQueryArgs
         return $this->withArg('orderby', $orderBy);
     }
 
-    public function withTaxQueryItem(array $item): self
+    public function withTaxQueryItem(array $item, string $relation = 'AND'): self
     {
         $instance = clone $this;
 
         $instance->args['tax_query'] = (array) ($instance->args['tax_query']
-            ?? ['relation' => 'AND']);
+            ?? ['relation' => $relation]);
 
         $instance->args['tax_query'][] = $item;
 

--- a/src/Infrastructure/Repository/WpQueryArgsBuilder.php
+++ b/src/Infrastructure/Repository/WpQueryArgsBuilder.php
@@ -88,26 +88,31 @@ final class WpQueryArgsBuilder
             $queryArgs = $this->applyFilter($filter, $queryArgs, $criteria->languageCode());
         }
 
-        foreach ($criteria->hisCodes() as $hisCode) {
-            $queryArgs = $this->applyHisCode($hisCode, $queryArgs);
+        if (count($criteria->hisCodes()) > 0) {
+            $queryArgs = $this->applyHisCodes($criteria->hisCodes(), $queryArgs);
         }
 
         return $queryArgs;
     }
 
-    public function applyHisCode(string $hisCode, WpQueryArgs $queryArgs): WpQueryArgs
+    /**
+     * @param array<string> $hisCodes
+     */
+    public function applyHisCodes(array $hisCodes, WpQueryArgs $queryArgs): WpQueryArgs
     {
-        $taxQueryItem = [
-            'relation' => 'AND',
-        ];
+        $hisCodesQuery = [];
 
-        try {
+        foreach ($hisCodes as $hisCode) {
+            $taxQueryItem = [
+                'relation' => 'AND',
+            ];
+
             $taxonomyToTermMapping = $this->campoKeysRepository->taxonomyToTermsMapFromCampoKeys(
                 CampoKeys::fromHisCode($hisCode)
             );
 
             if (count($taxonomyToTermMapping) === 0) {
-                return $queryArgs;
+                continue;
             }
 
             foreach ($taxonomyToTermMapping as $taxonomy => $termId) {
@@ -119,14 +124,16 @@ final class WpQueryArgsBuilder
                 ];
             }
 
-            return $queryArgs->withTaxQueryItem($taxQueryItem, 'OR');
-        } catch (RuntimeException) {
-            /*
-             * Return an empty result if one or more campo keys in HIS code are not matched to any terms.
-             * Otherwise invalid HIS codes would be matched to false results.
-             */
-            return $queryArgs->withArg('post__in', [0]);
+            $hisCodesQuery[] = $taxQueryItem;
         }
+
+        if (count($hisCodesQuery) === 0) {
+            return $queryArgs;
+        }
+
+        $hisCodesQuery['relation'] = 'OR';
+
+        return $queryArgs->withTaxQueryItem($hisCodesQuery);
     }
 
     private function applyOrderBy(

--- a/src/Infrastructure/Repository/WpQueryArgsBuilder.php
+++ b/src/Infrastructure/Repository/WpQueryArgsBuilder.php
@@ -119,7 +119,7 @@ final class WpQueryArgsBuilder
                 ];
             }
 
-            return $queryArgs->withTaxQueryItem($taxQueryItem);
+            return $queryArgs->withTaxQueryItem($taxQueryItem, 'OR');
         } catch (RuntimeException) {
             /*
              * Return an empty result if one or more campo keys in HIS code are not matched to any terms.

--- a/src/Infrastructure/Repository/WpQueryArgsBuilder.php
+++ b/src/Infrastructure/Repository/WpQueryArgsBuilder.php
@@ -107,9 +107,13 @@ final class WpQueryArgsBuilder
                 'relation' => 'AND',
             ];
 
-            $taxonomyToTermMapping = $this->campoKeysRepository->taxonomyToTermsMapFromCampoKeys(
-                CampoKeys::fromHisCode($hisCode)
-            );
+            try {
+                $taxonomyToTermMapping = $this->campoKeysRepository->taxonomyToTermsMapFromCampoKeys(
+                    CampoKeys::fromHisCode($hisCode)
+                );
+            } catch (RuntimeException) {
+                continue;
+            }
 
             if (count($taxonomyToTermMapping) === 0) {
                 continue;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


**What is the current behavior?** (You can also link to an open issue here)
Currently separating HIS codes by a comma in the `ids` attribute connects them by `AND` ([source](https://github.com/RRZE-Webteam/FAU-Studium-Common/blob/2541cfaf59327aa4b26cd288b3304a8e43e59f91/src/Infrastructure/Repository/WpQueryArgs.php#L47)). This makes it impossible to display programs using multiple codes.


**What is the new behavior (if this is a feature change)?**
The relation is changed to `OR`. Introduced the possibility to set any relation in the taxonomy parameter `tax_query`.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


**Other information**:
