### PR TITLE
Add default campo keys value

### DIFF
--- a/src/Application/DegreeProgramViewRaw.php
+++ b/src/Application/DegreeProgramViewRaw.php
@@ -201,7 +201,7 @@ final class DegreeProgramViewRaw implements JsonSerializable
             ),
             applyNowLink: MultilingualLink::fromArray($data[DegreeProgram::APPLY_NOW_LINK]),
             entryText: MultilingualString::fromArray($data[DegreeProgram::ENTRY_TEXT]),
-            campoKeys: CampoKeys::fromArray($data[DegreeProgram::CAMPO_KEYS]),
+            campoKeys: CampoKeys::fromArray($data[DegreeProgram::CAMPO_KEYS] ?? []),
         );
     }
 

--- a/src/Application/DegreeProgramViewTranslated.php
+++ b/src/Application/DegreeProgramViewTranslated.php
@@ -282,7 +282,7 @@ final class DegreeProgramViewTranslated implements JsonSerializable
             studentInitiatives: Link::fromArray($data[DegreeProgram::STUDENT_INITIATIVES]),
             applyNowLink: Link::fromArray($data[DegreeProgram::APPLY_NOW_LINK]),
             entryText: $data[DegreeProgram::ENTRY_TEXT],
-            campoKeys: CampoKeys::fromArray($data[DegreeProgram::CAMPO_KEYS]),
+            campoKeys: CampoKeys::fromArray($data[DegreeProgram::CAMPO_KEYS] ?? []),
         );
 
         if (empty($data[self::TRANSLATIONS])) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


**What is the current behavior?** (You can also link to an open issue here)
We are currently having issues with cached degree program data. The post meta values `fau_cache_degree_program_raw` and `fau_cache_degree_program_translated` don't include `campo_keys` value.


**What is the new behavior (if this is a feature change)?**
Added default values for `campo_keys` if the degree program data does not include them.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


**Other information**:
