### PR TITLE
[FAU-376] Ignore higher semester admission requirements in the search

### DIFF
--- a/src/Infrastructure/Repository/WpQueryArgsBuilder.php
+++ b/src/Infrastructure/Repository/WpQueryArgsBuilder.php
@@ -254,13 +254,6 @@ final class WpQueryArgsBuilder
                     'include_children' => true,
                 ],
                 [
-                    'taxonomy' => TeachingDegreeHigherSemesterAdmissionRequirementTaxonomy::KEY,
-                    'terms' => $filter->value(),
-                    'field' => 'slug',
-                    'compare' => 'IN',
-                    'include_children' => true,
-                ],
-                [
                     'taxonomy' => MasterDegreeAdmissionRequirementTaxonomy::KEY,
                     'terms' => $filter->value(),
                     'field' => 'slug',


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
https://inpsyde.atlassian.net/browse/FAU-376 (erroneously commented in https://inpsyde.atlassian.net/browse/FAU-400)


**What is the current behavior?** (You can also link to an open issue here)
Degree programs are assigned to different admission requirements taxonomies:  Bachelor's/teaching degree and Bachelor's/teaching degree at a higher semester. During filtering, both taxonomies are taken into account, which leads to an issue where the NC column in the list of degree programs displays irrelevant text.


**What is the new behavior (if this is a feature change)?**
Filtering degree programs is based only on the main Bachelor's/teaching degree taxonomy.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


**Other information**:
