### PR TITLE
[FAU-376] Include slugs in admission requirements data and allow the use of custom admission requirements

### DIFF
--- a/src/Application/AdmissionRequirementTranslated.php
+++ b/src/Application/AdmissionRequirementTranslated.php
@@ -11,6 +11,7 @@ use Fau\DegreeProgram\Common\Domain\AdmissionRequirement;
  *     name: string,
  *     link_text: string,
  *     link_url: string,
+ *     slug: string
  * }
  * @psalm-type AdmissionRequirementTranslatedType = AdmissionRequirementTranslated
  *             & array{parent: AdmissionRequirementTranslated|null}
@@ -20,15 +21,17 @@ final class AdmissionRequirementTranslated
     private function __construct(
         private Link $current,
         private ?AdmissionRequirementTranslated $parent,
+        private string $slug
     ) {
     }
 
     public static function new(
         Link $current,
         ?AdmissionRequirementTranslated $parent,
+        string $slug = ''
     ): self {
 
-        return new self($current, $parent);
+        return new self($current, $parent, $slug);
     }
 
     public static function fromAdmissionRequirement(
@@ -41,6 +44,7 @@ final class AdmissionRequirementTranslated
             $admissionRequirement->parent()
                 ? self::fromAdmissionRequirement($admissionRequirement->parent(), $languageCode)
                 : null,
+            $admissionRequirement->slug()
         );
     }
 
@@ -57,10 +61,12 @@ final class AdmissionRequirementTranslated
 
         /** @var AdmissionRequirementTranslatedType|null  $parentData */
         $parentData = $data[AdmissionRequirement::PARENT];
+        $slug = $data[AdmissionRequirement::SLUG] ?? '';
 
         return new self(
             Link::fromArray($currentData),
-            $parentData ? self::fromArray($parentData) : null
+            $parentData ? self::fromArray($parentData) : null,
+            $slug
         );
     }
 
@@ -73,6 +79,7 @@ final class AdmissionRequirementTranslated
         $parentData = $this->parent?->asArray();
         $currentData = $this->current->asArray();
         $currentData[AdmissionRequirement::PARENT] = $parentData;
+        $currentData[AdmissionRequirement::SLUG] = $this->slug;
 
         return $currentData;
     }
@@ -80,6 +87,11 @@ final class AdmissionRequirementTranslated
     public function name(): string
     {
         return $this->current->name();
+    }
+
+    public function slug(): string
+    {
+        return $this->slug;
     }
 
     public function linkText(): string

--- a/src/Application/Filter/AdmissionRequirementTypeFilter.php
+++ b/src/Application/Filter/AdmissionRequirementTypeFilter.php
@@ -4,25 +4,18 @@ declare(strict_types=1);
 
 namespace Fau\DegreeProgram\Common\Application\Filter;
 
-/**
- * @psalm-type AdmissionRequirementType = 'frei' | 'eingeschraenkt' | 'frei-mit-einschraenkung'
- */
 final class AdmissionRequirementTypeFilter implements Filter
 {
     public const FREE = 'frei';
-    public const FREE_WITH_RESTRICTION = 'frei-mit-einschraenkung';
     public const RESTRICTED = 'eingeschraenkt';
 
     public const KEY = 'admission-requirement';
 
     /**
-     * @var array<AdmissionRequirementType>
+     * @var array<string>
      */
     private array $types;
 
-    /**
-     * @psalm-param AdmissionRequirementType $types
-     */
     private function __construct(
         string ...$types
     ) {
@@ -35,9 +28,6 @@ final class AdmissionRequirementTypeFilter implements Filter
         return self::KEY;
     }
 
-    /**
-     * @psalm-return array<AdmissionRequirementType>
-     */
     public function value(): array
     {
         return array_unique($this->types);
@@ -56,7 +46,7 @@ final class AdmissionRequirementTypeFilter implements Filter
     }
 
     /**
-     * @psalm-return ?array<AdmissionRequirementType>
+     * @return array<string>|null
      */
     private static function sanitize(mixed $value): ?array
     {
@@ -68,12 +58,9 @@ final class AdmissionRequirementTypeFilter implements Filter
             return null;
         }
 
-        /** @psalm-var array<AdmissionRequirementType> $value */
-        $value = array_filter(
+        return array_filter(
             $value,
-            static fn ($item) => in_array($item, [self::FREE, self::FREE_WITH_RESTRICTION, self::RESTRICTED], true),
+            'is_string',
         );
-
-        return $value;
     }
 }

--- a/src/Domain/AdmissionRequirement.php
+++ b/src/Domain/AdmissionRequirement.php
@@ -12,6 +12,7 @@ namespace Fau\DegreeProgram\Common\Domain;
  *     name: MultilingualStringType,
  *     link_text: MultilingualStringType,
  *     link_url: MultilingualStringType,
+ *     slug: string
  * }
  *
  * @psalm-type AdmissionRequirementType = AdmissionRequirement & array{
@@ -22,6 +23,7 @@ final class AdmissionRequirement
 {
     public const ID = 'id';
     public const NAME = 'name';
+    public const SLUG = 'slug';
     public const LINK_TEXT = 'link_text';
     public const LINK_URL = 'link_url';
 
@@ -33,6 +35,7 @@ final class AdmissionRequirement
         'required' => [
             AdmissionRequirement::ID,
             AdmissionRequirement::NAME,
+            AdmissionRequirement::SLUG,
             AdmissionRequirement::LINK_TEXT,
             AdmissionRequirement::LINK_URL,
             AdmissionRequirement::PARENT,
@@ -43,6 +46,10 @@ final class AdmissionRequirement
                 'minLength' => 1,
             ],
             AdmissionRequirement::NAME => MultilingualString::SCHEMA,
+            AdmissionRequirement::SLUG => [
+                'type' => 'string',
+                'minLength' => 1,
+            ],
             AdmissionRequirement::LINK_TEXT => MultilingualString::SCHEMA,
             AdmissionRequirement::LINK_URL => MultilingualString::SCHEMA,
             AdmissionRequirement::PARENT => [
@@ -51,6 +58,7 @@ final class AdmissionRequirement
                 'required' => [
                     AdmissionRequirement::ID,
                     AdmissionRequirement::NAME,
+                    AdmissionRequirement::SLUG,
                 ],
                 'properties' => [
                     AdmissionRequirement::ID => [
@@ -58,6 +66,10 @@ final class AdmissionRequirement
                         'minLength' => 1,
                     ],
                     AdmissionRequirement::NAME => MultilingualString::SCHEMA,
+                    AdmissionRequirement::SLUG => [
+                        'type' => 'string',
+                        'minLength' => 1,
+                    ],
                 ],
             ],
         ],
@@ -69,6 +81,7 @@ final class AdmissionRequirement
         'required' => [
             AdmissionRequirement::ID,
             AdmissionRequirement::NAME,
+            AdmissionRequirement::SLUG,
             AdmissionRequirement::LINK_TEXT,
             AdmissionRequirement::LINK_URL,
         ],
@@ -78,6 +91,10 @@ final class AdmissionRequirement
                 'maxLength' => 0,
             ],
             AdmissionRequirement::NAME => MultilingualString::SCHEMA,
+            AdmissionRequirement::SLUG => [
+                'type' => 'string',
+                'maxLength' => 0,
+            ],
             AdmissionRequirement::LINK_TEXT => MultilingualString::SCHEMA,
             AdmissionRequirement::LINK_URL => MultilingualString::SCHEMA,
             AdmissionRequirement::PARENT => [
@@ -89,22 +106,25 @@ final class AdmissionRequirement
     private function __construct(
         private MultilingualLink $current,
         private ?AdmissionRequirement $parent,
+        private string $slug
     ) {
     }
 
     public static function new(
         MultilingualLink $current,
         ?AdmissionRequirement $parent,
+        string $slug = ''
     ): self {
 
-        return new self($current, $parent);
+        return new self($current, $parent, $slug);
     }
 
     public static function empty(): self
     {
         return new self(
             MultilingualLink::empty(),
-            null
+            null,
+            ''
         );
     }
 
@@ -122,10 +142,12 @@ final class AdmissionRequirement
 
         /** @var AdmissionRequirementType|null  $parentData */
         $parentData = $data[self::PARENT] ?? null;
+        $slug = $data[self::SLUG] ?? '';
 
         return new self(
             MultilingualLink::fromArray($currentData),
-            $parentData ? self::fromArray($parentData) : null
+            $parentData ? self::fromArray($parentData) : null,
+            $slug
         );
     }
 
@@ -138,6 +160,7 @@ final class AdmissionRequirement
         $parentData = $this->parent?->asArray();
         $currentData = $this->current->asArray();
         $currentData[self::PARENT] = $parentData;
+        $currentData[self::SLUG] = $this->slug;
 
         return $currentData;
     }
@@ -150,6 +173,11 @@ final class AdmissionRequirement
     public function name(): MultilingualString
     {
         return $this->current->name();
+    }
+
+    public function slug(): string
+    {
+        return $this->slug;
     }
 
     public function linkText(): MultilingualString

--- a/src/Infrastructure/Repository/WordPressDatabaseDegreeProgramRepository.php
+++ b/src/Infrastructure/Repository/WordPressDatabaseDegreeProgramRepository.php
@@ -307,6 +307,7 @@ final class WordPressDatabaseDegreeProgramRepository extends BilingualRepository
         return AdmissionRequirement::new(
             $this->bilingualLinkFromTerm($term),
             $parent instanceof WP_Term ? $this->admissionRequirement($parent) : null,
+            $term->slug
         );
     }
 

--- a/tests/resources/fixtures/degree_program.json
+++ b/tests/resources/fixtures/degree_program.json
@@ -262,8 +262,10 @@
           "de": "",
           "en": ""
         },
-        "parent": null
-      }
+        "parent": null,
+        "slug": "frei"
+      },
+      "slug": "admission_bachelor"
     },
     "teaching_degree_higher_semester": {
       "id": "term:24",
@@ -299,8 +301,10 @@
           "de": "",
           "en": ""
         },
-        "parent": null
-      }
+        "parent": null,
+        "slug": "frei"
+      },
+      "slug": "admission_higher_semester"
     },
     "master": {
       "id": "term:19",
@@ -336,8 +340,10 @@
           "de": "",
           "en": ""
         },
-        "parent": null
-      }
+        "parent": null,
+        "slug": "nich_frei"
+      },
+      "slug": "admission_master"
     }
   },
   "content_related_master_requirements": {

--- a/tests/unit/Domain/AdmissionRequirementsTest.php
+++ b/tests/unit/Domain/AdmissionRequirementsTest.php
@@ -30,6 +30,7 @@ class AdmissionRequirementsTest extends UnitTestCase
                     'en' => 'Link URL Bachelor EN',
                 ],
                 'parent' => null,
+                'slug' => 'name_bachelor',
             ],
             'teaching_degree_higher_semester' => [
                 'id' => 'term:6',
@@ -66,7 +67,9 @@ class AdmissionRequirementsTest extends UnitTestCase
                         'en' => '',
                     ],
                     'parent' => null,
+                    'slug' => 'frei',
                 ],
+                'slug' => 'name_higher_semester',
             ],
             'master' => [
                 'id' => 'term:7',
@@ -86,6 +89,7 @@ class AdmissionRequirementsTest extends UnitTestCase
                     'en' => 'Link URL Master EN',
                 ],
                 'parent' => null,
+                'slug' => 'name_master',
             ],
         ];
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature


**What is the current behavior?** (You can also link to an open issue here)
https://inpsyde.atlassian.net/browse/FAU-376


**What is the new behavior (if this is a feature change)?**
Slugs are included in admission requirements data, also allowed the use of custom admission requirements(to filter it by slugs)


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


**Other information**:
