### PR TITLE
[FAU-434] Include campo keys from all related terms to degree program data

### DIFF
--- a/src/Domain/CampoKeys.php
+++ b/src/Domain/CampoKeys.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Fau\DegreeProgram\Common\Domain;
 
 /**
- * @psalm-type CampoKeysMap = array<value-of<self::SUPPORTED_CAMPO_KEYS>, array<int, string>|string>
+ * @psalm-type CampoKeysMap = array<value-of<self::SUPPORTED_CAMPO_KEYS>, array<int, string>>
  */
 final class CampoKeys
 {
@@ -45,8 +45,6 @@ final class CampoKeys
         DegreeProgram::LOCATION,
     ];
 
-    private const HIS_CODE_DELIMITER = '|';
-
     private function __construct(
         /**
          * @var CampoKeysMap $map
@@ -66,18 +64,6 @@ final class CampoKeys
     public static function fromArray(array $map): self
     {
         return new self($map);
-    }
-
-    public static function fromHisCode(string $hisCode): self
-    {
-        $parts = explode(self::HIS_CODE_DELIMITER, $hisCode);
-        $map = [
-            DegreeProgram::DEGREE => $parts[0] ?? null,
-            DegreeProgram::AREA_OF_STUDY => $parts[1] ?? null,
-            DegreeProgram::LOCATION => $parts[6] ?? null,
-        ];
-
-        return new self(array_filter($map, fn($value) => !is_null($value)));
     }
 
     /**

--- a/src/Domain/CampoKeys.php
+++ b/src/Domain/CampoKeys.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Fau\DegreeProgram\Common\Domain;
 
 /**
- * @psalm-type CampoKeysMap = array<value-of<self::SUPPORTED_CAMPO_KEYS>, string>
+ * @psalm-type CampoKeysMap = array<value-of<self::SUPPORTED_CAMPO_KEYS>, array<int, string>|string>
  */
 final class CampoKeys
 {
@@ -13,13 +13,13 @@ final class CampoKeys
         'type' => 'object',
         'properties' => [
             DegreeProgram::DEGREE => [
-                'type' => 'string',
+                'type' => 'array',
             ],
             DegreeProgram::AREA_OF_STUDY => [
-                'type' => 'string',
+                'type' => 'array',
             ],
             DegreeProgram::LOCATION => [
-                'type' => 'string',
+                'type' => 'array',
             ],
         ],
     ];
@@ -28,13 +28,13 @@ final class CampoKeys
         'type' => 'object',
         'properties' => [
             DegreeProgram::DEGREE => [
-                'type' => 'string',
+                'type' => 'array',
             ],
             DegreeProgram::AREA_OF_STUDY => [
-                'type' => 'string',
+                'type' => 'array',
             ],
             DegreeProgram::LOCATION => [
-                'type' => 'string',
+                'type' => 'array',
             ],
         ],
     ];

--- a/src/Infrastructure/Repository/CampoKeysRepository.php
+++ b/src/Infrastructure/Repository/CampoKeysRepository.php
@@ -51,7 +51,7 @@ final class CampoKeysRepository
                 continue;
             }
 
-            $map[$campoKeyType] = $campoKey;
+            $map[$campoKeyType][$term->term_id] = $campoKey;
         }
 
         return CampoKeys::fromArray($map);
@@ -69,9 +69,9 @@ final class CampoKeysRepository
         $campoKeys = $campoKeys->asArray();
 
         foreach (self::TAXONOMY_TO_CAMPO_KEY_MAP as $taxonomy => $campoKeyType) {
-            $campoKey = $campoKeys[$campoKeyType] ?? '';
+            $campoKey = $campoKeys[$campoKeyType] ?? null;
 
-            if ($campoKey === '') {
+            if (!is_string($campoKey) || $campoKey === '') {
                 continue;
             }
 

--- a/src/Infrastructure/Repository/CampoKeysRepository.php
+++ b/src/Infrastructure/Repository/CampoKeysRepository.php
@@ -24,6 +24,8 @@ final class CampoKeysRepository
 
     public const CAMPO_KEY_TERM_META_KEY = 'uniquename';
 
+    private const HIS_CODE_DELIMITER = '|';
+
     public function degreeProgramCampoKeys(DegreeProgramId $degreeProgramId): CampoKeys
     {
         /** @var WP_Error|array<WP_Term> $terms */
@@ -62,11 +64,11 @@ final class CampoKeysRepository
      *
      * @return array<string, int>
      */
-    public function taxonomyToTermsMapFromCampoKeys(CampoKeys $campoKeys): array
+    public function taxonomyToTermsMapFromHisCode(string $hisCode): array
     {
         $result = [];
 
-        $campoKeys = $campoKeys->asArray();
+        $campoKeys = $this->campoKeysFromHisCode($hisCode);
 
         foreach (self::TAXONOMY_TO_CAMPO_KEY_MAP as $taxonomy => $campoKeyType) {
             $campoKey = $campoKeys[$campoKeyType] ?? null;
@@ -100,5 +102,17 @@ final class CampoKeysRepository
         }
 
         return $terms[0] ?? null;
+    }
+
+    public function campoKeysFromHisCode(string $hisCode): array
+    {
+        $parts = explode(self::HIS_CODE_DELIMITER, $hisCode);
+        $map = [
+            DegreeProgram::DEGREE => $parts[0] ?? null,
+            DegreeProgram::AREA_OF_STUDY => $parts[1] ?? null,
+            DegreeProgram::LOCATION => $parts[6] ?? null,
+        ];
+
+        return array_filter($map, fn($value) => !is_null($value));
     }
 }

--- a/src/Infrastructure/Repository/CampoKeysRepository.php
+++ b/src/Infrastructure/Repository/CampoKeysRepository.php
@@ -60,7 +60,6 @@ final class CampoKeysRepository
     /**
      * Return a map of taxonomy keys to terms based on a given HIS code.
      *
-     * @throws RuntimeException
      * @return array<string, int>
      */
     public function taxonomyToTermsMapFromCampoKeys(CampoKeys $campoKeys): array
@@ -77,12 +76,7 @@ final class CampoKeysRepository
             }
 
             $term = $this->findTermByCampoKey($taxonomy, $campoKey);
-
-            if (! $term instanceof WP_Term) {
-                throw new RuntimeException('Could not find term for Campo key: ' . $campoKey);
-            }
-
-            $result[$taxonomy] = $term->term_id;
+            $result[$taxonomy] = $term instanceof WP_Term ? $term->term_id : 0;
         }
 
         return $result;

--- a/src/Infrastructure/Repository/WpQueryArgsBuilder.php
+++ b/src/Infrastructure/Repository/WpQueryArgsBuilder.php
@@ -107,9 +107,7 @@ final class WpQueryArgsBuilder
                 'relation' => 'AND',
             ];
 
-            $taxonomyToTermMapping = $this->campoKeysRepository->taxonomyToTermsMapFromCampoKeys(
-                CampoKeys::fromHisCode($hisCode)
-            );
+            $taxonomyToTermMapping = $this->campoKeysRepository->taxonomyToTermsMapFromHisCode($hisCode);
 
             if (count($taxonomyToTermMapping) === 0) {
                 continue;

--- a/src/Infrastructure/Repository/WpQueryArgsBuilder.php
+++ b/src/Infrastructure/Repository/WpQueryArgsBuilder.php
@@ -107,13 +107,9 @@ final class WpQueryArgsBuilder
                 'relation' => 'AND',
             ];
 
-            try {
-                $taxonomyToTermMapping = $this->campoKeysRepository->taxonomyToTermsMapFromCampoKeys(
-                    CampoKeys::fromHisCode($hisCode)
-                );
-            } catch (RuntimeException) {
-                continue;
-            }
+            $taxonomyToTermMapping = $this->campoKeysRepository->taxonomyToTermsMapFromCampoKeys(
+                CampoKeys::fromHisCode($hisCode)
+            );
 
             if (count($taxonomyToTermMapping) === 0) {
                 continue;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature


**What is the current behavior?** (You can also link to an open issue here)
https://inpsyde.atlassian.net/browse/FAU-434

1) If a degree program has multiple terms with different campo keys, we only pass the keys from the last term([code](https://github.com/RRZE-Webteam/FAU-Studium-Common/blob/d83e8ea07501f8ab93d52fd2de7c44020751ec1d/src/Infrastructure/Repository/CampoKeysRepository.php#L54)).

2) if the specified campo keys don't match any terms, the `tax_query` is omitted entirely, causing the query to return all posts, which is unintended.

**What is the new behavior (if this is a feature change)?**

1) All related term campo keys are now included in the degree program data.
2) Instead of omitting the `tax_query`, we now pass 0 as required term ID, which ensures no posts are returned, as there is no term with ID 0.

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


**Other information**:
https://github.com/RRZE-Webteam/FAU-Studium-Embed/pull/42 