### PR TITLE
[FAU-402] Introduce editableOnly method for admin-only taxonomy visibility and editing

### DIFF
--- a/src/Infrastructure/Content/Taxonomy/Taxonomy.php
+++ b/src/Infrastructure/Content/Taxonomy/Taxonomy.php
@@ -48,6 +48,20 @@ abstract class Taxonomy
         );
     }
 
+    final public static function editableOnly(): static
+    {
+        return self::default()->merge(
+            [
+                'public' => false,
+                'show_ui' => true,
+                'show_in_menu' => true,
+                'show_in_nav_menus' => false,
+                'show_in_rest' => true,
+                'meta_box_cb' => false,
+            ]
+        );
+    }
+
     final public function args(): array
     {
         return $this->args;

--- a/tests/unit/Content/TaxonomyTest.php
+++ b/tests/unit/Content/TaxonomyTest.php
@@ -57,6 +57,22 @@ final class TaxonomyTest extends UnitTestCase
                 'hierarchical' => true,
                 'rest_base' => 'degree',
                 'public' => false,
+                'show_ui' => true,
+                'show_in_menu' => true,
+                'show_in_nav_menus' => false,
+                'show_in_rest' => true,
+                'meta_box_cb' => false,
+            ],
+            DegreeTaxonomy::editableOnly()->args()
+        );
+
+        $this->assertSame(
+            [
+                'label' => 'Degrees',
+                'labels' => $expectedLabels,
+                'hierarchical' => true,
+                'rest_base' => 'degree',
+                'public' => false,
                 'show_in_rest' => false,
             ],
             DegreeTaxonomy::hidden()->args()


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature.


**What is the current behavior?** (You can also link to an open issue here)
https://inpsyde.atlassian.net/browse/FAU-402


**What is the new behavior (if this is a feature change)?**
This PR introduces a new method `editableOnly`. The purpose of this method is to allow taxonomy terms to be managed in the WordPress admin dashboard while disabling their single term view on the front end.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


**Other information**:
