### PR TITLE
[FAU-443, FAU-444] Make “German language skills for international students” taxonomy hierarchical

### DIFF
--- a/src/Domain/MultilingualLink.php
+++ b/src/Domain/MultilingualLink.php
@@ -6,12 +6,13 @@ namespace Fau\DegreeProgram\Common\Domain;
 
 /**
  * @psalm-import-type MultilingualStringType from MultilingualString
- * @psalm-type MultilingualLinkType = array{
+ * @psalm-type MultilingualLink = array{
  *     id: string,
  *     name: MultilingualStringType,
  *     link_text: MultilingualStringType,
  *     link_url: MultilingualStringType
  * }
+ * @psalm-type MultilingualLinkType = MultilingualLink & array{parent?: MultilingualLink|null}
  */
 final class MultilingualLink
 {
@@ -19,10 +20,11 @@ final class MultilingualLink
     public const NAME = 'name';
     public const LINK_TEXT = 'link_text';
     public const LINK_URL = 'link_url';
+    public const PARENT = 'parent';
 
     public const SCHEMA = [
         'type' => 'object',
-        'additionalProperties' => false,
+        'additionalProperties' => true,
         'required' => [
             MultilingualLink::ID,
             MultilingualLink::NAME,
@@ -47,6 +49,7 @@ final class MultilingualLink
             MultilingualLink::NAME,
             MultilingualLink::LINK_TEXT,
             MultilingualLink::LINK_URL,
+            MultilingualLink::PARENT,
         ],
         'properties' => [
             MultilingualLink::ID => [
@@ -56,6 +59,19 @@ final class MultilingualLink
             MultilingualLink::NAME => MultilingualString::SCHEMA,
             MultilingualLink::LINK_TEXT => MultilingualString::SCHEMA,
             MultilingualLink::LINK_URL => MultilingualString::SCHEMA,
+            MultilingualLink::PARENT => [
+                'type' => ['object', 'null'],
+                'additionalProperties' => true,
+                'required' => [
+                    MultilingualLink::ID,
+                ],
+                'properties' => [
+                    MultilingualLink::ID => [
+                        'type' => 'string',
+                        'minLength' => 1,
+                    ],
+                ],
+            ],
         ],
     ];
 
@@ -64,6 +80,7 @@ final class MultilingualLink
         private MultilingualString $name,
         private MultilingualString $linkText,
         private MultilingualString $linkUrl,
+        private ?MultilingualLink $parent,
     ) {
     }
 
@@ -72,9 +89,10 @@ final class MultilingualLink
         MultilingualString $name,
         MultilingualString $linkText,
         MultilingualString $linkUrl,
+        ?MultilingualLink $parent = null
     ): self {
 
-        return new self($id, $name, $linkText, $linkUrl);
+        return new self($id, $name, $linkText, $linkUrl, $parent);
     }
 
     public static function empty(): self
@@ -84,6 +102,7 @@ final class MultilingualLink
             MultilingualString::empty(),
             MultilingualString::empty(),
             MultilingualString::empty(),
+            null
         );
     }
 
@@ -92,11 +111,15 @@ final class MultilingualLink
      */
     public static function fromArray(array $data): self
     {
+        /** @var MultilingualLink|null $parentData */
+        $parentData = $data[self::PARENT] ?? null;
+
         return new self(
             $data[self::ID],
             MultilingualString::fromArray($data[self::NAME]),
             MultilingualString::fromArray($data[self::LINK_TEXT]),
             MultilingualString::fromArray($data[self::LINK_URL]),
+            !empty($parentData) ? self::fromArray($parentData) : null,
         );
     }
 
@@ -105,11 +128,15 @@ final class MultilingualLink
      */
     public function asArray(): array
     {
+        /** @var MultilingualLink|null $parentData */
+        $parentData = $this->parent?->asArray();
+
         return [
             self::ID => $this->id,
             self::NAME => $this->name->asArray(),
             self::LINK_TEXT => $this->linkText->asArray(),
             self::LINK_URL => $this->linkUrl->asArray(),
+            self::PARENT => $parentData,
         ];
     }
 
@@ -131,5 +158,10 @@ final class MultilingualLink
     public function linkUrl(): MultilingualString
     {
         return $this->linkUrl;
+    }
+
+    public function parent(): ?MultilingualLink
+    {
+        return $this->parent;
     }
 }

--- a/src/Infrastructure/Content/Taxonomy/GermanLanguageSkillsForInternationalStudentsTaxonomy.php
+++ b/src/Infrastructure/Content/Taxonomy/GermanLanguageSkillsForInternationalStudentsTaxonomy.php
@@ -44,6 +44,6 @@ final class GermanLanguageSkillsForInternationalStudentsTaxonomy extends Taxonom
 
     protected function isHierarchical(): bool
     {
-        return false;
+        return true;
     }
 }

--- a/src/Infrastructure/Repository/BilingualRepository.php
+++ b/src/Infrastructure/Repository/BilingualRepository.php
@@ -125,13 +125,16 @@ abstract class BilingualRepository
         );
     }
 
-    final protected function bilingualLinkFromTerm(?WP_Term $term): MultilingualLink
+    final protected function bilingualLinkFromTerm(?WP_Term $term, string $taxonomy): MultilingualLink
     {
+        $parentTerm = $term instanceof WP_Term && $term->parent ? get_term($term->parent, $taxonomy) : null;
+
         return MultilingualLink::new(
             $term instanceof WP_Term ? $this->idGenerator->generateTermId($term) : '',
             name: $this->bilingualTermName($term),
             linkText: $this->bilingualTermMeta($term, MultilingualLink::LINK_TEXT),
             linkUrl: $this->bilingualTermMeta($term, MultilingualLink::LINK_URL),
+            parent: $parentTerm instanceof WP_Term ? $this->bilingualLinkFromTerm($parentTerm, $taxonomy) : null,
         );
     }
 
@@ -144,7 +147,7 @@ abstract class BilingualRepository
 
         $links = [];
         foreach ($terms as $term) {
-            $links[] = $this->bilingualLinkFromTerm($term);
+            $links[] = $this->bilingualLinkFromTerm($term, $taxonomy);
         }
 
         return MultilingualLinks::new(...$links);

--- a/src/Infrastructure/Repository/BilingualRepository.php
+++ b/src/Infrastructure/Repository/BilingualRepository.php
@@ -125,16 +125,16 @@ abstract class BilingualRepository
         );
     }
 
-    final protected function bilingualLinkFromTerm(?WP_Term $term, string $taxonomy): MultilingualLink
+    final protected function bilingualLinkFromTerm(?WP_Term $term): MultilingualLink
     {
-        $parentTerm = $term instanceof WP_Term && $term->parent ? get_term($term->parent, $taxonomy) : null;
+        $parentTerm = $term instanceof WP_Term && $term->parent ? get_term($term->parent, $term->taxonomy) : null;
 
         return MultilingualLink::new(
             $term instanceof WP_Term ? $this->idGenerator->generateTermId($term) : '',
             name: $this->bilingualTermName($term),
             linkText: $this->bilingualTermMeta($term, MultilingualLink::LINK_TEXT),
             linkUrl: $this->bilingualTermMeta($term, MultilingualLink::LINK_URL),
-            parent: $parentTerm instanceof WP_Term ? $this->bilingualLinkFromTerm($parentTerm, $taxonomy) : null,
+            parent: $parentTerm instanceof WP_Term ? $this->bilingualLinkFromTerm($parentTerm) : null,
         );
     }
 
@@ -147,7 +147,7 @@ abstract class BilingualRepository
 
         $links = [];
         foreach ($terms as $term) {
-            $links[] = $this->bilingualLinkFromTerm($term, $taxonomy);
+            $links[] = $this->bilingualLinkFromTerm($term);
         }
 
         return MultilingualLinks::new(...$links);

--- a/src/Infrastructure/Repository/WordPressDatabaseDegreeProgramRepository.php
+++ b/src/Infrastructure/Repository/WordPressDatabaseDegreeProgramRepository.php
@@ -146,21 +146,18 @@ final class WordPressDatabaseDegreeProgramRepository extends BilingualRepository
                         $post,
                         BachelorOrTeachingDegreeAdmissionRequirementTaxonomy::KEY,
                     ),
-                    BachelorOrTeachingDegreeAdmissionRequirementTaxonomy::KEY,
                 ),
                 teachingDegreeHigherSemester: $this->admissionRequirement(
                     $this->firstTerm(
                         $post,
                         TeachingDegreeHigherSemesterAdmissionRequirementTaxonomy::KEY,
                     ),
-                    TeachingDegreeHigherSemesterAdmissionRequirementTaxonomy::KEY,
                 ),
                 master: $this->admissionRequirement(
                     $this->firstTerm(
                         $post,
                         MasterDegreeAdmissionRequirementTaxonomy::KEY,
                     ),
-                    MasterDegreeAdmissionRequirementTaxonomy::KEY,
                 ),
             ),
             contentRelatedMasterRequirements: $this->bilingualPostMeta(
@@ -189,13 +186,11 @@ final class WordPressDatabaseDegreeProgramRepository extends BilingualRepository
                     $post,
                     GermanLanguageSkillsForInternationalStudentsTaxonomy::KEY,
                 ),
-                GermanLanguageSkillsForInternationalStudentsTaxonomy::KEY,
             ),
             startOfSemester: $this->bilingualLinkFromOption(DegreeProgram::START_OF_SEMESTER),
             semesterDates: $this->bilingualLinkFromOption(DegreeProgram::SEMESTER_DATES),
             examinationsOffice: $this->bilingualLinkFromTerm(
                 $this->firstTerm($post, ExaminationsOfficeTaxonomy::KEY),
-                ExaminationsOfficeTaxonomy::KEY,
             ),
             examinationRegulations: (string) get_post_meta(
                 $postId,
@@ -212,7 +207,6 @@ final class WordPressDatabaseDegreeProgramRepository extends BilingualRepository
             studentAdvice: $this->bilingualLinkFromOption(DegreeProgram::STUDENT_ADVICE),
             subjectSpecificAdvice: $this->bilingualLinkFromTerm(
                 $this->firstTerm($post, SubjectSpecificAdviceTaxonomy::KEY),
-                SubjectSpecificAdviceTaxonomy::KEY,
             ),
             serviceCenters: $this->bilingualLinkFromOption(DegreeProgram::SERVICE_CENTERS),
             infoBrochure: (string) get_post_meta(
@@ -241,7 +235,6 @@ final class WordPressDatabaseDegreeProgramRepository extends BilingualRepository
             ),
             applyNowLink: $this->bilingualLinkFromTerm(
                 $this->firstTerm($post, ApplyNowLinkTaxonomy::KEY),
-                ApplyNowLinkTaxonomy::KEY,
             ),
             combinations: $this->idsFromPostMeta($postId, DegreeProgram::COMBINATIONS),
             limitedCombinations: $this->idsFromPostMeta(
@@ -303,7 +296,7 @@ final class WordPressDatabaseDegreeProgramRepository extends BilingualRepository
         );
     }
 
-    private function admissionRequirement(?WP_Term $term, string $taxonomy): AdmissionRequirement
+    private function admissionRequirement(?WP_Term $term): AdmissionRequirement
     {
         if (!$term instanceof WP_Term) {
             return AdmissionRequirement::empty();
@@ -312,8 +305,8 @@ final class WordPressDatabaseDegreeProgramRepository extends BilingualRepository
         $parent = $term->parent ? get_term($term->parent) : null;
 
         return AdmissionRequirement::new(
-            $this->bilingualLinkFromTerm($term, $taxonomy),
-            $parent instanceof WP_Term ? $this->admissionRequirement($parent, $taxonomy) : null,
+            $this->bilingualLinkFromTerm($term),
+            $parent instanceof WP_Term ? $this->admissionRequirement($parent) : null,
             $term->slug
         );
     }

--- a/src/Infrastructure/Repository/WordPressDatabaseDegreeProgramRepository.php
+++ b/src/Infrastructure/Repository/WordPressDatabaseDegreeProgramRepository.php
@@ -144,20 +144,23 @@ final class WordPressDatabaseDegreeProgramRepository extends BilingualRepository
                 bachelorOrTeachingDegree: $this->admissionRequirement(
                     $this->firstTerm(
                         $post,
-                        BachelorOrTeachingDegreeAdmissionRequirementTaxonomy::KEY
-                    )
+                        BachelorOrTeachingDegreeAdmissionRequirementTaxonomy::KEY,
+                    ),
+                    BachelorOrTeachingDegreeAdmissionRequirementTaxonomy::KEY,
                 ),
                 teachingDegreeHigherSemester: $this->admissionRequirement(
                     $this->firstTerm(
                         $post,
-                        TeachingDegreeHigherSemesterAdmissionRequirementTaxonomy::KEY
-                    )
+                        TeachingDegreeHigherSemesterAdmissionRequirementTaxonomy::KEY,
+                    ),
+                    TeachingDegreeHigherSemesterAdmissionRequirementTaxonomy::KEY,
                 ),
                 master: $this->admissionRequirement(
                     $this->firstTerm(
                         $post,
                         MasterDegreeAdmissionRequirementTaxonomy::KEY,
-                    )
+                    ),
+                    MasterDegreeAdmissionRequirementTaxonomy::KEY,
                 ),
             ),
             contentRelatedMasterRequirements: $this->bilingualPostMeta(
@@ -182,15 +185,17 @@ final class WordPressDatabaseDegreeProgramRepository extends BilingualRepository
                 true
             ),
             germanLanguageSkillsForInternationalStudents: $this->bilingualLinkFromTerm(
-                $this->firstTopTerm(
+                $this->firstTerm(
                     $post,
                     GermanLanguageSkillsForInternationalStudentsTaxonomy::KEY,
-                )
+                ),
+                GermanLanguageSkillsForInternationalStudentsTaxonomy::KEY,
             ),
             startOfSemester: $this->bilingualLinkFromOption(DegreeProgram::START_OF_SEMESTER),
             semesterDates: $this->bilingualLinkFromOption(DegreeProgram::SEMESTER_DATES),
             examinationsOffice: $this->bilingualLinkFromTerm(
-                $this->firstTerm($post, ExaminationsOfficeTaxonomy::KEY)
+                $this->firstTerm($post, ExaminationsOfficeTaxonomy::KEY),
+                ExaminationsOfficeTaxonomy::KEY,
             ),
             examinationRegulations: (string) get_post_meta(
                 $postId,
@@ -206,7 +211,8 @@ final class WordPressDatabaseDegreeProgramRepository extends BilingualRepository
             department: $this->bilingualPostMeta($post, DegreeProgram::DEPARTMENT),
             studentAdvice: $this->bilingualLinkFromOption(DegreeProgram::STUDENT_ADVICE),
             subjectSpecificAdvice: $this->bilingualLinkFromTerm(
-                $this->firstTerm($post, SubjectSpecificAdviceTaxonomy::KEY)
+                $this->firstTerm($post, SubjectSpecificAdviceTaxonomy::KEY),
+                SubjectSpecificAdviceTaxonomy::KEY,
             ),
             serviceCenters: $this->bilingualLinkFromOption(DegreeProgram::SERVICE_CENTERS),
             infoBrochure: (string) get_post_meta(
@@ -235,6 +241,7 @@ final class WordPressDatabaseDegreeProgramRepository extends BilingualRepository
             ),
             applyNowLink: $this->bilingualLinkFromTerm(
                 $this->firstTerm($post, ApplyNowLinkTaxonomy::KEY),
+                ApplyNowLinkTaxonomy::KEY,
             ),
             combinations: $this->idsFromPostMeta($postId, DegreeProgram::COMBINATIONS),
             limitedCombinations: $this->idsFromPostMeta(
@@ -273,27 +280,6 @@ final class WordPressDatabaseDegreeProgramRepository extends BilingualRepository
         return $terms[0];
     }
 
-    private function firstTopTerm(WP_Post $post, string $taxonomy): ?WP_Term
-    {
-        $terms = get_the_terms($post, $taxonomy);
-
-        if (!is_array($terms)) {
-            return null;
-        }
-
-        if (!isset($terms[0]) || !$terms[0] instanceof WP_Term) {
-            return null;
-        }
-
-        if (!$terms[0]->parent) {
-            return $terms[0];
-        }
-
-        $parent = get_term($terms[0]->parent);
-
-        return $parent instanceof WP_Term ? $parent : $terms[0];
-    }
-
     private function degree(WP_Post $post): Degree
     {
         $term = $this->firstTerm($post, DegreeTaxonomy::KEY);
@@ -317,7 +303,7 @@ final class WordPressDatabaseDegreeProgramRepository extends BilingualRepository
         );
     }
 
-    private function admissionRequirement(?WP_Term $term): AdmissionRequirement
+    private function admissionRequirement(?WP_Term $term, string $taxonomy): AdmissionRequirement
     {
         if (!$term instanceof WP_Term) {
             return AdmissionRequirement::empty();
@@ -326,8 +312,8 @@ final class WordPressDatabaseDegreeProgramRepository extends BilingualRepository
         $parent = $term->parent ? get_term($term->parent) : null;
 
         return AdmissionRequirement::new(
-            $this->bilingualLinkFromTerm($term),
-            $parent instanceof WP_Term ? $this->admissionRequirement($parent) : null,
+            $this->bilingualLinkFromTerm($term, $taxonomy),
+            $parent instanceof WP_Term ? $this->admissionRequirement($parent, $taxonomy) : null,
             $term->slug
         );
     }

--- a/src/Infrastructure/Repository/WordPressDatabaseDegreeProgramRepository.php
+++ b/src/Infrastructure/Repository/WordPressDatabaseDegreeProgramRepository.php
@@ -182,7 +182,7 @@ final class WordPressDatabaseDegreeProgramRepository extends BilingualRepository
                 true
             ),
             germanLanguageSkillsForInternationalStudents: $this->bilingualLinkFromTerm(
-                $this->firstTerm(
+                $this->firstTopTerm(
                     $post,
                     GermanLanguageSkillsForInternationalStudentsTaxonomy::KEY,
                 )
@@ -271,6 +271,27 @@ final class WordPressDatabaseDegreeProgramRepository extends BilingualRepository
         }
 
         return $terms[0];
+    }
+
+    private function firstTopTerm(WP_Post $post, string $taxonomy): ?WP_Term
+    {
+        $terms = get_the_terms($post, $taxonomy);
+
+        if (!is_array($terms)) {
+            return null;
+        }
+
+        if (!isset($terms[0]) || !$terms[0] instanceof WP_Term) {
+            return null;
+        }
+
+        if (!$terms[0]->parent) {
+            return $terms[0];
+        }
+
+        $parent = get_term($terms[0]->parent);
+
+        return $parent instanceof WP_Term ? $parent : $terms[0];
     }
 
     private function degree(WP_Post $post): Degree

--- a/tests/resources/fixtures/degree_program.json
+++ b/tests/resources/fixtures/degree_program.json
@@ -103,7 +103,8 @@
         "id": "term_meta:11:link_url",
         "de": "https:\/\/fau.localhost\/faculty-math",
         "en": "https:\/\/fau.localhost\/faculty-math-en"
-      }
+      },
+      "parent": null
     }
   ],
   "location": [
@@ -380,6 +381,25 @@
       "id": "term_meta:16:link_url",
       "de": "https:\/\/fau.localhost\/german-language-skills-international-students",
       "en": "https:\/\/fau.localhost\/german-language-skills-international-students-en"
+    },
+    "parent": {
+      "id": "term:12",
+      "name": {
+        "id": "term:12:name",
+        "de": "German language skills for international students (parent)",
+        "en": "German language skills for international students EN (parent)"
+      },
+      "link_text": {
+        "id": "term_meta:12:link_text",
+        "de": "Link to german language skills for international students (parent)",
+        "en": "Link to german language skills for international students EN (parent)"
+      },
+      "link_url": {
+        "id": "term_meta:12:link_url",
+        "de": "https:\/\/fau.localhost\/german-language-skills-international-students-parent",
+        "en": "https:\/\/fau.localhost\/german-language-skills-international-students-en-parent"
+      },
+      "parent": null
     }
   },
   "start_of_semester": {
@@ -398,7 +418,8 @@
       "id": "option:fau_start_of_semester:link_url",
       "de": "https:\/\/fau.localhost\/start-of-semester",
       "en": "https:\/\/fau.localhost\/start-of-semester-en"
-    }
+    },
+    "parent": null
   },
   "semester_dates": {
     "id": "option:fau_semester_dates",
@@ -416,7 +437,8 @@
       "id": "option:fau_semester_dates:link_url",
       "de": "https:\/\/fau.localhost\/semester-dates",
       "en": "https:\/\/fau.localhost\/semester-dates-en"
-    }
+    },
+    "parent": null
   },
   "examinations_office": {
     "id": "term:15",
@@ -434,7 +456,8 @@
       "id": "term_meta:15:link_url",
       "de": "https:\/\/fau.localhost\/examinations-office",
       "en": "https:\/\/fau.localhost\/examinations-office-en"
-    }
+    },
+    "parent": null
   },
   "examination_regulations": "https://fau.localhost/examinations-regulations",
   "module_handbook": "Module handbook value",
@@ -464,7 +487,8 @@
       "id": "option:fau_student_advice:link_url",
       "de": "https:\/\/fau.localhost\/career-service",
       "en": "https:\/\/fau.localhost\/career-service-en"
-    }
+    },
+    "parent": null
   },
   "subject_specific_advice": {
     "id": "term:6",
@@ -482,7 +506,8 @@
       "id": "term_meta:6:link_url",
       "de": "https:\/\/fau.localhost\/advice",
       "en": "https:\/\/fau.localhost\/advice-en"
-    }
+    },
+    "parent": null
   },
   "service_centers": {
     "id": "option:fau_service_centers",
@@ -500,7 +525,8 @@
       "id": "option:fau_service_centers:link_url",
       "de": "https:\/\/fau.localhost\/counseling",
       "en": "https:\/\/fau.localhost\/counseling-en"
-    }
+    },
+    "parent": null
   },
   "info_brochure": "Info Brochure 2023",
   "semester_fee": {
@@ -519,7 +545,8 @@
       "id": "option:fau_semester_fee:link_url",
       "de": "https:\/\/fau.localhost\/semester-fee",
       "en": "https:\/\/fau.localhost\/semester-fee-en"
-    }
+    },
+    "parent": null
   },
   "degree_program_fees": {
     "id": "post_meta:25:degree_program_fees",
@@ -542,7 +569,8 @@
       "id": "option:fau_abroad_opportunities:link_url",
       "de": "https:\/\/fau.localhost\/abroad",
       "en": "https:\/\/fau.localhost\/abroad-en"
-    }
+    },
+    "parent": null
   },
   "keywords": [
     {
@@ -573,7 +601,8 @@
         "id": "term_meta:3:link_url",
         "de": "https:\/\/fau.localhost\/biology",
         "en": "https:\/\/fau.localhost\/biology-en"
-      }
+      },
+      "parent": null
     },
     {
       "id": "term:38",
@@ -591,7 +620,8 @@
         "id": "term_meta:38:link_url",
         "de": "https:\/\/fau.localhost\/biology-math",
         "en": "https:\/\/fau.localhost\/biology-math-en"
-      }
+      },
+      "parent": null
     }
   ],
   "combinations": [
@@ -617,7 +647,8 @@
       "id": "option:fau_notes_for_international_applicants:link_url",
       "de": "https:\/\/fau.localhost\/notes-for-intl-applicants",
       "en": "https:\/\/fau.localhost\/notes-for-intl-applicants-en"
-    }
+    },
+    "parent": null
   },
   "student_initiatives": {
     "id": "option:student_initiatives",
@@ -635,7 +666,8 @@
       "id": "option:student_initiatives:link_url",
       "de": "https:\/\/fau.localhost\/fsi",
       "en": "https:\/\/fau.localhost\/fsi-en"
-    }
+    },
+    "parent": null
   },
   "apply_now_link": {
     "id": "term:39",
@@ -653,7 +685,8 @@
       "id": "term_meta:39:link_url",
       "de": "https://campo.fau.de",
       "en": "https://campo.fau.de"
-    }
+    },
+    "parent": null
   },
   "entry_text": {
     "id": "post_meta:25:entry_text",

--- a/tests/unit/Domain/MultilingualLinkTest.php
+++ b/tests/unit/Domain/MultilingualLinkTest.php
@@ -28,6 +28,7 @@ class MultilingualLinkTest extends TestCase
                 'de' => 'https://fau.localhost/faculty-math',
                 'en' => 'https://fau.localhost/faculty-math-en',
             ],
+            'parent' => null
         ];
 
         $sut = MultilingualLink::fromArray($array);

--- a/tests/unit/Domain/MultilingualLinkTest.php
+++ b/tests/unit/Domain/MultilingualLinkTest.php
@@ -28,7 +28,7 @@ class MultilingualLinkTest extends TestCase
                 'de' => 'https://fau.localhost/faculty-math',
                 'en' => 'https://fau.localhost/faculty-math-en',
             ],
-            'parent' => null
+            'parent' => null,
         ];
 
         $sut = MultilingualLink::fromArray($array);

--- a/tests/unit/Domain/MultilingualLinksTest.php
+++ b/tests/unit/Domain/MultilingualLinksTest.php
@@ -29,6 +29,7 @@ class MultilingualLinksTest extends UnitTestCase
                     'de' => 'https://fau.localhost/biology',
                     'en' => 'https://fau.localhost/biology-en',
                 ],
+                'parent' => null
             ],
             [
                 'id' => 'term:38',
@@ -47,6 +48,7 @@ class MultilingualLinksTest extends UnitTestCase
                     'de' => 'https://fau.localhost/biology-math',
                     'en' => 'https://fau.localhost/biology-math-en',
                 ],
+                'parent' => null
             ],
         ];
 

--- a/tests/unit/Domain/MultilingualLinksTest.php
+++ b/tests/unit/Domain/MultilingualLinksTest.php
@@ -29,7 +29,7 @@ class MultilingualLinksTest extends UnitTestCase
                     'de' => 'https://fau.localhost/biology',
                     'en' => 'https://fau.localhost/biology-en',
                 ],
-                'parent' => null
+                'parent' => null,
             ],
             [
                 'id' => 'term:38',
@@ -48,7 +48,7 @@ class MultilingualLinksTest extends UnitTestCase
                     'de' => 'https://fau.localhost/biology-math',
                     'en' => 'https://fau.localhost/biology-math-en',
                 ],
-                'parent' => null
+                'parent' => null,
             ],
         ];
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature.


**What is the current behavior?** (You can also link to an open issue here)
https://inpsyde.atlassian.net/browse/FAU-443
https://inpsyde.atlassian.net/browse/FAU-444

Discussion: https://inpsyde.slack.com/archives/C045KFJ9MB5/p1734520808952019

**What is the new behavior (if this is a feature change)?**
- `German language skills for international students` taxonomy is hierarchical
- `MultilingualLink` has been extended with a `parent` property to enable proper synchronization of both child and parent terms to consuming websites 


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


**Other information**:
Related PR that incorporates the use of `parent` property for synchronization to consuming websites: https://github.com/RRZE-Webteam/FAU-Studium-Embed/pull/49