### PR TITLE
[FAU-455] Support new shortcodes and blocks

### DIFF
--- a/src/Domain/DegreeProgramSanitizer.php
+++ b/src/Domain/DegreeProgramSanitizer.php
@@ -51,6 +51,8 @@ interface DegreeProgramSanitizer
         'alert',
         'contact',
         'fau-video',
+        'fachanteile',
+        'faudir',
     ];
 
     public const ALLOWED_BLOCKS = [
@@ -61,6 +63,8 @@ interface DegreeProgramSanitizer
         'core/shortcode',
         'core/quote',
         'fau/description-list',
+        'fau/faudir-block',
+        'fau-degree-program/shares',
     ];
 
     public function sanitizeContentField(string $content): string;

--- a/src/Infrastructure/Logger/WordPressLogger.php
+++ b/src/Infrastructure/Logger/WordPressLogger.php
@@ -66,7 +66,7 @@ final class WordPressLogger extends AbstractLogger
 
     private function isDebugMode(): bool
     {
-        /** @psalm-suppress TypeDoesNotContainType */
+        /** @psalm-suppress RedundantCondition */
         return defined('WP_DEBUG') && WP_DEBUG;
     }
 

--- a/src/Infrastructure/TemplateRenderer/TemplateRenderer.php
+++ b/src/Infrastructure/TemplateRenderer/TemplateRenderer.php
@@ -28,7 +28,7 @@ final class TemplateRenderer implements Renderer
     public function render(string $templateName, array $data = []): string
     {
         $level = ob_get_level();
-        /** @psalm-suppress TypeDoesNotContainType */
+        /** @psalm-suppress RedundantCondition */
         $isDebug = defined('WP_DEBUG') && WP_DEBUG;
 
         try {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature


**What is the current behavior?** (You can also link to an open issue here)
https://inpsyde.atlassian.net/browse/FAU-455


**What is the new behavior (if this is a feature change)?**
Allow the "fachanteile"  and "faudir" shortcodes,  as well as "fau/faudir-block" and "fau-degree-program/shares" blocks in content fields.

Also fixed a few Psalm issues that appeared after a package update. For some reason, Psalm assumed that if `WP_DEBUG` is defined, its value is always `true`.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


**Other information**:
Related PR: https://github.com/RRZE-Webteam/FAU-Studium/pull/161
