### PR TITLE
[FAU-463] Remove teaser image field from degree program

### DIFF
--- a/config/schema_draft.php
+++ b/config/schema_draft.php
@@ -28,7 +28,6 @@ return [
         ],
         DegreeProgram::SLUG => MultilingualString::SCHEMA,
         DegreeProgram::FEATURED_IMAGE => Image::SCHEMA,
-        DegreeProgram::TEASER_IMAGE => Image::SCHEMA,
         DegreeProgram::TITLE => MultilingualString::SCHEMA,
         DegreeProgram::SUBTITLE => MultilingualString::SCHEMA,
         DegreeProgram::STANDARD_DURATION => [

--- a/config/schema_publish.php
+++ b/config/schema_publish.php
@@ -28,7 +28,6 @@ return [
         ],
         DegreeProgram::SLUG => MultilingualString::SCHEMA,
         DegreeProgram::FEATURED_IMAGE => Image::SCHEMA_REQUIRED,
-        DegreeProgram::TEASER_IMAGE => Image::SCHEMA_REQUIRED,
         DegreeProgram::TITLE => MultilingualString::SCHEMA_REQUIRED,
         DegreeProgram::SUBTITLE => MultilingualString::SCHEMA,
         DegreeProgram::STANDARD_DURATION => [

--- a/src/Application/DegreeProgramViewRaw.php
+++ b/src/Application/DegreeProgramViewRaw.php
@@ -30,7 +30,6 @@ final class DegreeProgramViewRaw implements JsonSerializable
         private DegreeProgramId $id,
         private MultilingualString $slug,
         private Image $featuredImage,
-        private Image $teaserImage,
         private MultilingualString $title,
         private MultilingualString $subtitle,
         private string $standardDuration,
@@ -90,7 +89,6 @@ final class DegreeProgramViewRaw implements JsonSerializable
             $data[DegreeProgram::ID],
             $data[DegreeProgram::SLUG],
             $data[DegreeProgram::FEATURED_IMAGE],
-            $data[DegreeProgram::TEASER_IMAGE],
             $data[DegreeProgram::TITLE],
             $data[DegreeProgram::SUBTITLE],
             $data[DegreeProgram::STANDARD_DURATION],
@@ -151,7 +149,6 @@ final class DegreeProgramViewRaw implements JsonSerializable
             id: DegreeProgramId::fromInt($data[DegreeProgram::ID]),
             slug: MultilingualString::fromArray($data[DegreeProgram::SLUG]),
             featuredImage: Image::fromArray($data[DegreeProgram::FEATURED_IMAGE]),
-            teaserImage: Image::fromArray($data[DegreeProgram::TEASER_IMAGE]),
             title: MultilingualString::fromArray($data[DegreeProgram::TITLE]),
             subtitle: MultilingualString::fromArray($data[DegreeProgram::SUBTITLE]),
             standardDuration: $data[DegreeProgram::STANDARD_DURATION],
@@ -216,7 +213,6 @@ final class DegreeProgramViewRaw implements JsonSerializable
             DegreeProgram::ID => $this->id->asInt(),
             DegreeProgram::SLUG => $this->slug->asArray(),
             DegreeProgram::FEATURED_IMAGE => $this->featuredImage->asArray(),
-            DegreeProgram::TEASER_IMAGE => $this->teaserImage->asArray(),
             DegreeProgram::TITLE => $this->title->asArray(),
             DegreeProgram::SUBTITLE => $this->subtitle->asArray(),
             DegreeProgram::STANDARD_DURATION => $this->standardDuration,
@@ -287,11 +283,6 @@ final class DegreeProgramViewRaw implements JsonSerializable
     public function featuredImage(): Image
     {
         return $this->featuredImage;
-    }
-
-    public function teaserImage(): Image
-    {
-        return $this->teaserImage;
     }
 
     public function title(): MultilingualString

--- a/src/Application/DegreeProgramViewTranslated.php
+++ b/src/Application/DegreeProgramViewTranslated.php
@@ -28,7 +28,6 @@ use JsonSerializable;
  *     slug: string,
  *     lang: LanguageCodes,
  *     featured_image: ImageViewType,
- *     teaser_image: ImageViewType,
  *     title: string,
  *     subtitle: string,
  *     standard_duration: string,
@@ -107,7 +106,6 @@ final class DegreeProgramViewTranslated implements JsonSerializable
          */
         private string $lang,
         private ImageView $featuredImage,
-        private ImageView $teaserImage,
         private string $title,
         private string $subtitle,
         private string $standardDuration,
@@ -172,7 +170,6 @@ final class DegreeProgramViewTranslated implements JsonSerializable
             slug: '',
             lang: $languageCode,
             featuredImage: ImageView::empty(),
-            teaserImage: ImageView::empty(),
             title: '',
             subtitle: '',
             standardDuration: '',
@@ -245,7 +242,6 @@ final class DegreeProgramViewTranslated implements JsonSerializable
             slug: $data[DegreeProgram::SLUG],
             lang: $data[self::LANG],
             featuredImage: ImageView::fromArray($data[DegreeProgram::FEATURED_IMAGE]),
-            teaserImage: ImageView::fromArray($data[DegreeProgram::TEASER_IMAGE]),
             title: $data[DegreeProgram::TITLE],
             subtitle: $data[DegreeProgram::SUBTITLE],
             standardDuration: $data[DegreeProgram::STANDARD_DURATION],
@@ -324,7 +320,6 @@ final class DegreeProgramViewTranslated implements JsonSerializable
             DegreeProgram::SLUG => $this->slug,
             self::LANG => $this->lang,
             DegreeProgram::FEATURED_IMAGE => $this->featuredImage->asArray(),
-            DegreeProgram::TEASER_IMAGE => $this->teaserImage->asArray(),
             DegreeProgram::TITLE => $this->title,
             DegreeProgram::SUBTITLE => $this->subtitle,
             DegreeProgram::STANDARD_DURATION => $this->standardDuration,
@@ -493,11 +488,6 @@ final class DegreeProgramViewTranslated implements JsonSerializable
     public function featuredImage(): ImageView
     {
         return $this->featuredImage;
-    }
-
-    public function teaserImage(): ImageView
-    {
-        return $this->teaserImage;
     }
 
     public function title(): string

--- a/src/Domain/DegreeProgram.php
+++ b/src/Domain/DegreeProgram.php
@@ -22,7 +22,6 @@ use RuntimeException;
  *     id: int,
  *     slug: MultilingualStringType,
  *     featured_image: array{id: int, url: string},
- *     teaser_image: array{id: int, url: string},
  *     title: MultilingualStringType,
  *     subtitle: MultilingualStringType,
  *     standard_duration: string,
@@ -76,7 +75,6 @@ final class DegreeProgram
     public const ID = 'id';
     public const SLUG = 'slug';
     public const FEATURED_IMAGE = 'featured_image';
-    public const TEASER_IMAGE = 'teaser_image';
     public const TITLE = 'title';
     public const SUBTITLE = 'subtitle';
     public const STANDARD_DURATION = 'standard_duration';
@@ -136,7 +134,6 @@ final class DegreeProgram
         private MultilingualString $slug,
         //--- At a glance (“Auf einen Blick”) ---//
         private Image $featuredImage,
-        private Image $teaserImage,
         private MultilingualString $title,
         private MultilingualString $subtitle,
         /**
@@ -412,7 +409,6 @@ final class DegreeProgram
 
         $this->slug = MultilingualString::fromArray($data[self::SLUG]);
         $this->featuredImage = Image::fromArray($data[self::FEATURED_IMAGE]);
-        $this->teaserImage = Image::fromArray($data[self::TEASER_IMAGE]);
         $this->title = MultilingualString::fromArray($data[self::TITLE]);
         $this->subtitle = MultilingualString::fromArray($data[self::SUBTITLE]);
         $this->standardDuration = $data[self::STANDARD_DURATION];
@@ -475,7 +471,6 @@ final class DegreeProgram
      *     id: DegreeProgramId,
      *     slug: MultilingualString,
      *     featured_image: Image,
-     *     teaser_image: Image,
      *     title: MultilingualString,
      *     subtitle: MultilingualString,
      *     standard_duration: string,
@@ -534,7 +529,6 @@ final class DegreeProgram
             self::ID => $this->id,
             self::SLUG => $this->slug,
             self::FEATURED_IMAGE => $this->featuredImage,
-            self::TEASER_IMAGE => $this->teaserImage,
             self::TITLE => $this->title,
             self::SUBTITLE => $this->subtitle,
             self::STANDARD_DURATION => $this->standardDuration,

--- a/src/Infrastructure/Repository/WordPressDatabaseDegreeProgramRepository.php
+++ b/src/Infrastructure/Repository/WordPressDatabaseDegreeProgramRepository.php
@@ -72,7 +72,6 @@ final class WordPressDatabaseDegreeProgramRepository extends BilingualRepository
         }
 
         $featuredImageId = (int) get_post_thumbnail_id($post);
-        $teaserImageId = (int) get_post_meta($postId, DegreeProgram::TEASER_IMAGE, true);
 
         /**
          * @var string $videos
@@ -93,10 +92,6 @@ final class WordPressDatabaseDegreeProgramRepository extends BilingualRepository
             featuredImage: Image::new(
                 $featuredImageId,
                 (string) wp_get_attachment_image_url($featuredImageId, 'full')
-            ),
-            teaserImage: Image::new(
-                $teaserImageId,
-                (string) wp_get_attachment_image_url($teaserImageId, 'full')
             ),
             title: MultilingualString::fromTranslations(
                 $this->idGenerator->generatePostId($post, 'title'),
@@ -364,8 +359,6 @@ final class WordPressDatabaseDegreeProgramRepository extends BilingualRepository
         );
 
         $metas = [
-            DegreeProgram::TEASER_IMAGE =>
-                $degreeProgramViewRaw->teaserImage()->id(),
             BilingualRepository::addEnglishSuffix('title') =>
                 $degreeProgramViewRaw->title()->inEnglish(),
             BilingualRepository::addEnglishSuffix('post_name') =>

--- a/src/Infrastructure/Repository/WordPressDatabaseDegreeProgramViewRepository.php
+++ b/src/Infrastructure/Repository/WordPressDatabaseDegreeProgramViewRepository.php
@@ -118,11 +118,6 @@ final class WordPressDatabaseDegreeProgramViewRepository implements DegreeProgra
                 DegreeProgram::FEATURED_IMAGE,
                 $title
             ),
-            teaserImage: $this->imageView(
-                $raw->teaserImage(),
-                DegreeProgram::TEASER_IMAGE,
-                $title
-            ),
             title: $raw->title()->asString($languageCode),
             subtitle: $raw->subtitle()->asString($languageCode),
             standardDuration: $raw->standardDuration(),
@@ -193,7 +188,7 @@ final class WordPressDatabaseDegreeProgramViewRepository implements DegreeProgra
     }
 
     /**
-     * @psalm-param 'featured_image' | 'teaser_image' $type
+     * @psalm-param 'featured_image' $type
      */
     private function imageView(Image $image, string $type, string $alt): ImageView
     {

--- a/src/Infrastructure/RestApi/TranslatedDegreeProgramController.php
+++ b/src/Infrastructure/RestApi/TranslatedDegreeProgramController.php
@@ -398,14 +398,6 @@ final class TranslatedDegreeProgramController extends WP_REST_Controller
                 ),
                 'type' => 'object',
             ],
-            DegreeProgram::TEASER_IMAGE => [
-                'description' => _x(
-                    'Teaser image.',
-                    'rest_api: schema item description',
-                    'fau-degree-program-common'
-                ),
-                'type' => 'object',
-            ],
             DegreeProgram::TITLE => [
                 'description' => _x(
                     'Title.',

--- a/src/Infrastructure/Validator/JsonSchemaDegreeProgramDataValidator.php
+++ b/src/Infrastructure/Validator/JsonSchemaDegreeProgramDataValidator.php
@@ -32,7 +32,6 @@ final class JsonSchemaDegreeProgramDataValidator implements DegreeProgramDataVal
         DegreeProgram::ID,
         DegreeProgram::SLUG,
         DegreeProgram::FEATURED_IMAGE,
-        DegreeProgram::TEASER_IMAGE,
         DegreeProgram::TITLE,
         DegreeProgram::SUBTITLE,
         DegreeProgram::STANDARD_DURATION,

--- a/tests/resources/fixtures/degree_program.json
+++ b/tests/resources/fixtures/degree_program.json
@@ -9,10 +9,6 @@
     "id": 9,
     "url": "https:\/\/fau.localhost\/wp-content\/uploads\/2022\/12\/viber_image_2022-05-27_15-30-39-852.jpg"
   },
-  "teaser_image": {
-    "id": 14,
-    "url": "https:\/\/fau.localhost\/wp-content\/uploads\/2022\/12\/abstract-1-1528080.jpg"
-  },
   "title": {
     "id": "post:25:title",
     "de": "Master of Art FAU",

--- a/tests/src/FixtureDegreeProgramDataProviderTrait.php
+++ b/tests/src/FixtureDegreeProgramDataProviderTrait.php
@@ -52,7 +52,6 @@ trait FixtureDegreeProgramDataProviderTrait
             id: DegreeProgramId::fromInt($id),
             slug: MultilingualString::empty(),
             featuredImage: Image::empty(),
-            teaserImage: Image::empty(),
             title: MultilingualString::empty(),
             subtitle: MultilingualString::empty(),
             standardDuration: '',

--- a/tests/src/Repository/StubDegreeProgramRepository.php
+++ b/tests/src/Repository/StubDegreeProgramRepository.php
@@ -90,11 +90,6 @@ final class StubDegreeProgramRepository implements DegreeProgramRepository, Degr
                 $raw->featuredImage()->url(),
                 '',
             ),
-            teaserImage: ImageView::new(
-                $raw->teaserImage()->id(),
-                $raw->teaserImage()->url(),
-                '',
-            ),
             title: $raw->title()->asString($languageCode),
             subtitle: $raw->subtitle()->asString($languageCode),
             standardDuration: $raw->standardDuration(),

--- a/tests/unit/Domain/DegreeProgramTest.php
+++ b/tests/unit/Domain/DegreeProgramTest.php
@@ -68,10 +68,6 @@ class DegreeProgramTest extends UnitTestCase
             $result['featured_image']->id()
         );
         $this->assertSame(
-            14,
-            $result['teaser_image']->id()
-        );
-        $this->assertSame(
             'Master of Art FAU EN',
             $result['title']->inEnglish()
         );


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature


**What is the current behavior?** (You can also link to an open issue here)
https://inpsyde.atlassian.net/browse/FAU-463


**What is the new behavior (if this is a feature change)?**
Dropped teaser image in the data layer: domain model, view models, repositories, REST schema, draft/publish JSON schemas, validation and fixtures. The shared `Image`/`ImageView` value objects stay (still used by the featured image).


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


**Other information**:
Related PR - https://github.com/RRZE-Webteam/FAU-Studium/pull/176